### PR TITLE
修复 type = "ollama" 时 JSON 解析出错

### DIFF
--- a/aipyapp/aipy/llm.py
+++ b/aipyapp/aipy/llm.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import time
+import json
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
@@ -227,11 +228,11 @@ class OllamaClient(BaseClient):
             status = self.console.status(f"[dim white]{self.name} {T('thinking')}...", spinner='runner')
             response_panel = Panel(status, title=title, border_style="blue")
             live.update(response_panel)
-            
-            for chunk in response:
-                msg = chunk.json()
+            for chunk in response.iter_lines():
+                chunk = chunk.decode(encoding='utf-8')
+                msg = json.loads(chunk)
                 if msg['done']:
-                    usage = self._parse_usage(chunk.usage)
+                    usage = self._parse_usage(msg)
                     break
 
                 if 'message' in msg and 'content' in msg['message'] and msg['message']['content']:
@@ -500,4 +501,3 @@ class LLM(object):
         ret = llm(self.history, instruction, system_prompt=system_prompt)
         event_bus.broadcast('response_complete', {'llm': name, 'content': ret})
         return ret
-        


### PR DESCRIPTION
- Ollama API返回的是多行 JSON，无法直接 loads，需要逐行遍历
- 去掉 chunk.usage，状态为 done 的那行包含了 token 消费情况，直接解析