### PR TITLE
improve: 优化系统提示词，解决大模型首次生成代码无法识别pandas所用引擎对应依赖库的问题

### DIFF
--- a/aipyapp/aipy/prompt.py
+++ b/aipyapp/aipy/prompt.py
@@ -63,6 +63,20 @@ font_options = {
 }
 ```
 
+在使用 pandas 处理文件时，需要在代码中显式指定使用引擎名称，并使用`runtime.install_packages`方法安装引擎所对应依赖库。
+否则无法识别安装引擎所需要的可选依赖，导致出现`Missing optional dependency`错误。
+示例代码如下：
+```python
+import pandas as pd
+
+if runtime.install_packages('openpyxl'):
+    print("成功安装openpyxl依赖")
+else:
+    print("Error: 无法安装openpyxl依赖", file=sys.stderr)
+
+df = pd.read_excel("data.xlsx", engine="openpyxl")
+```
+
 ## 全局 `runtime` 对象
 `runtime` 对象提供一些协助代码完成任务的方法。
 


### PR DESCRIPTION
- 虽然pandas是预装第三方模块，但是使用pandas处理文件时，依赖使用引擎对应第三方模块。
- 若大模型生成代码时，没有显式指定pandas使用引擎名称，则不会生成安装第三方模块的代码，导致大模型首次生成代码执行必然出现`Missing optional dependency`错误。
- 在提示词中要求大模型显式指定pandas使用引擎名称，并使用`runtime.install_packages`方法安装引擎所对应依赖库，可以解决这个问题。