### PR TITLE
fix:Windows环境，当大模型回复消息中包含emoji表情符号，保存json结果的时候，出现UnicodeEncodeError错误

### DIFF
--- a/aipyapp/aipy/task.py
+++ b/aipyapp/aipy/task.py
@@ -81,14 +81,14 @@ class Task:
             return
 
     def done(self):
-        #import pdb;pdb.set_trace()
         instruction = self.instruction
         task = {'instruction': instruction}
         task['llm'] = self.llm.history.json()
         task['runner'] = self.runner.history
         filename = get_safe_filename(instruction, extension='.json') or f"{self.task_id}.json"
         try:
-            json.dump(task, open(filename, 'w'), ensure_ascii=False, indent=4)
+            with open(filename, 'w', encoding='utf-8') as file:
+                json.dump(task, file, ensure_ascii=False, indent=4)
         except Exception as e:
             self.console.print_exception()
 


### PR DESCRIPTION
- Windows环境，当大模型回复消息中包含emoji表情符号，保存json结果的时候，出现UnicodeEncodeError错误
- 如图所示：

![error](https://github.com/user-attachments/assets/a89642db-9f05-48a7-bbf1-07e0b58e2913)
