### PR TITLE
fix: 优化主任务中while循环的逻辑

### DIFF
--- a/aipyapp/aipy/task.py
+++ b/aipyapp/aipy/task.py
@@ -211,15 +211,19 @@ class Task:
         max_rounds = max_rounds or self.max_rounds
         if not max_rounds or max_rounds < 1:
             max_rounds = self.MAX_ROUNDS
-        response = self.llm(instruction, system_prompt=system_prompt, name=llm)
-        while response and rounds <= max_rounds:
+        while rounds <= max_rounds:
+            if rounds == 1:
+                response = self.llm(instruction, system_prompt=system_prompt, name=llm)
+            else:
+                response = self.process_code_reply(blocks, llm)
+            if not response:
+                break
+            if event_bus.is_stopped():
+                break
             blocks = self.parse_reply(response)
             if 'main' not in blocks:
                 break
             rounds += 1
-            response = self.process_code_reply(blocks, llm)
-            if event_bus.is_stopped():
-                break
         self.print_summary()
         os.write(1, b'\a\a\a')
 


### PR DESCRIPTION
- 主任务中现有的while循环逻辑，有一点小问题：
  * 当循环执行到最后一轮的时候（rounds == max_rounds）
  * 代码中会执行`process_code_reply`函数（该函数包含本地执行和大模型请求）
  * 但是这一次的执行是无意义的，因为此时`rounds`等于`max_rounds+1`，代码不会再进入循环，`process_code_reply`函数的response结果不会被`parse_reply`函数去解析