### PR TITLE
Add OAuth2 OpenAI Client support

### DIFF
--- a/aipyapp/config/llm.py
+++ b/aipyapp/config/llm.py
@@ -37,6 +37,9 @@ PROVIDERS = {
         "models_endpoint": "/models",
         "type": "gemini"
     },
+    "OAuth2": {
+        "type": "oauth2"
+    }
 }
 
 def get_providers():

--- a/aipyapp/llm/__init__.py
+++ b/aipyapp/llm/__init__.py
@@ -7,6 +7,7 @@ from .base import ChatMessage, BaseClient
 from .base_openai import OpenAIBaseClient
 from .client_claude import ClaudeClient
 from .client_ollama import OllamaClient
+from .client_oauth2 import OAuth2Client
 
 __all__ = ['ChatMessage', 'CLIENTS']
 
@@ -58,6 +59,7 @@ CLIENTS = {
     "deepseek": DeepSeekClient,
     'grok': GrokClient,
     'trust': TrustClient,
-    'azure': AzureOpenAIClient
+    'azure': AzureOpenAIClient,
+    'oauth2': OAuth2Client
 }
 

--- a/aipyapp/llm/client_oauth2.py
+++ b/aipyapp/llm/client_oauth2.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import requests
+from .base import BaseClient
+from .base_openai import OpenAIBaseClient
+from typing import Optional, Dict
+
+class OAuth2Client(OpenAIBaseClient):
+    """
+    OAuth2-based LLM client that:
+    1. First gets token using client_id/client_secret
+    2. Then uses the token to make LLM API calls
+    """
+    
+    def __init__(self, config: Dict):
+        super().__init__(config)
+        self._token_url = config.get("token_url")
+        self._client_id = config.get("client_id")
+        self._client_secret = config.get("client_secret")
+        self._access_token: Optional[str] = None
+    
+    def usable(self) -> bool:
+        """Check if required OAuth2 config exists"""
+        return all([
+            self._token_url,
+            self._client_id,
+            self._client_secret,
+            self._api_key,  # This would be the LLM API key from parent class
+            self._base_url  # LLM endpoint URL
+        ])
+    
+    def _get_access_token(self) -> str:
+        """Get OAuth2 access token using client credentials"""
+        if self._access_token:
+            return self._access_token
+            
+        auth_data = {
+            'client_id': self._client_id,
+            'client_secret': self._client_secret,
+            'grant_type': 'client_credentials'
+        }
+        
+        response = requests.post(
+            self._token_url,
+            data=auth_data
+        )
+        response.raise_for_status()
+        token_data = response.json()
+        self._access_token = token_data['access_token']
+        return self._access_token
+    
+    def _get_client_headers(self) -> Dict[str, str]:
+        """Get headers with Authorization token"""
+        headers = super()._get_client_headers()
+        headers['Authorization'] = f"Bearer {self._get_access_token()}"
+        return headers
+
+    def get_completion(self, messages):
+        """Get completion from LLM with fresh authentication headers"""
+        headers = self._get_client_headers()
+        # Merge headers into existing params
+        if 'headers' in self._params:
+            self._params['headers'].update(headers)
+        else:
+            self._params['headers'] = headers
+
+        return super().get_completion(messages)

--- a/aipyapp/llm/client_oauth2.py
+++ b/aipyapp/llm/client_oauth2.py
@@ -1,68 +1,68 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import requests
-from .base import BaseClient
-from .base_openai import OpenAIBaseClient
+import time
+import httpx
 from typing import Optional, Dict
+from .base_openai import OpenAIBaseClient
 
 class OAuth2Client(OpenAIBaseClient):
     """
-    OAuth2-based LLM client that:
+    OAuth2-based OpenAI LLM client that:
     1. First gets token using client_id/client_secret
     2. Then uses the token to make LLM API calls
     """
-    
     def __init__(self, config: Dict):
         super().__init__(config)
         self._token_url = config.get("token_url")
         self._client_id = config.get("client_id")
         self._client_secret = config.get("client_secret")
         self._access_token: Optional[str] = None
-    
+        self._token_expires = 0
+
     def usable(self) -> bool:
-        """Check if required OAuth2 config exists"""
         return all([
             self._token_url,
             self._client_id,
             self._client_secret,
-            self._api_key,  # This would be the LLM API key from parent class
-            self._base_url  # LLM endpoint URL
+            self._base_url
         ])
-    
+
+    def _get_client(self):
+        self._api_key = self._get_access_token()
+        return super()._get_client()
+
     def _get_access_token(self) -> str:
         """Get OAuth2 access token using client credentials"""
-        if self._access_token:
+        current_time = time.time()
+
+        # Return existing token if it's still valid (with 300 seconds buffer)
+        if self._access_token and current_time < (self._token_expires - 300):
             return self._access_token
-            
+
         auth_data = {
             'client_id': self._client_id,
             'client_secret': self._client_secret,
             'grant_type': 'client_credentials'
         }
-        
-        response = requests.post(
-            self._token_url,
-            data=auth_data
-        )
-        response.raise_for_status()
-        token_data = response.json()
-        self._access_token = token_data['access_token']
+
+        with httpx.Client(timeout=self._timeout, verify=self._tls_verify) as client:
+            response = client.post(
+                self._token_url,
+                data=auth_data
+            )
+            response.raise_for_status()
+            token_data = response.json()
+            self._access_token = token_data['access_token']
+
+        # Calculate expiration time (default to 5 mins if not provided)
+        expires_in = token_data.get("expires_in", 300)
+        self._token_expires = current_time + expires_in
+
         return self._access_token
-    
-    def _get_client_headers(self) -> Dict[str, str]:
-        """Get headers with Authorization token"""
-        headers = super()._get_client_headers()
-        headers['Authorization'] = f"Bearer {self._get_access_token()}"
-        return headers
-
+        
     def get_completion(self, messages):
-        """Get completion from LLM with fresh authentication headers"""
-        headers = self._get_client_headers()
-        # Merge headers into existing params
-        if 'headers' in self._params:
-            self._params['headers'].update(headers)
-        else:
-            self._params['headers'] = headers
+        response = super().get_completion(messages)
+        self._client = None
 
-        return super().get_completion(messages)
+        return response


### PR DESCRIPTION
In our company, the LLM provided is using OAuth2 token for authentication although it's API and request/response are compatible with OpenAI.  It's like putting an API gateway before the real OpenAI API.