### PR TITLE
feat: add MiniMax LLM provider support (default MiniMax-M3)

### DIFF
--- a/aipyapp/config/llm.py
+++ b/aipyapp/config/llm.py
@@ -37,6 +37,11 @@ PROVIDERS = {
         "models_endpoint": "/models",
         "type": "gemini"
     },
+    "MiniMax": {
+        "api_base": "https://api.minimax.io/v1",
+        "models_endpoint": "/models",
+        "type": "minimax"
+    },
     "OAuth2": {
         "type": "oauth2"
     }

--- a/aipyapp/llm/manager.py
+++ b/aipyapp/llm/manager.py
@@ -99,6 +99,11 @@ class MistralClient(OpenAIBaseClient):
     MODEL = 'devstral-2512'
 
 
+class MiniMaxClient(OpenAIBaseClient):
+    BASE_URL = 'https://api.minimax.io/v1'
+    MODEL = 'MiniMax-M2.5'
+
+
 CLIENTS = {
     "openai": OpenAIClient,
     "openaiv2": OpenAIClientV2,
@@ -115,6 +120,7 @@ CLIENTS = {
     'bigmodel': BigModelClient,
     'z': ZClient,
     'mistral': MistralClient,
+    'minimax': MiniMaxClient,
 }
 
 

--- a/aipyapp/llm/manager.py
+++ b/aipyapp/llm/manager.py
@@ -101,7 +101,7 @@ class MistralClient(OpenAIBaseClient):
 
 class MiniMaxClient(OpenAIBaseClient):
     BASE_URL = 'https://api.minimax.io/v1'
-    MODEL = 'MiniMax-M2.7'
+    MODEL = 'MiniMax-M3'
 
 
 CLIENTS = {

--- a/aipyapp/llm/manager.py
+++ b/aipyapp/llm/manager.py
@@ -101,7 +101,7 @@ class MistralClient(OpenAIBaseClient):
 
 class MiniMaxClient(OpenAIBaseClient):
     BASE_URL = 'https://api.minimax.io/v1'
-    MODEL = 'MiniMax-M2.5'
+    MODEL = 'MiniMax-M2.7'
 
 
 CLIENTS = {

--- a/aipyapp/res/models.yaml
+++ b/aipyapp/res/models.yaml
@@ -214,6 +214,26 @@ Anthropic:
       output: 15.00
 
 MiniMax:
+  MiniMax-M2.7:
+    description: MiniMax latest flagship model with enhanced reasoning, text generation and function calling
+    capabilities: [TEXT, FUNCTION_CALLING, REASONING]
+    context_length: 204800
+    max_output_tokens: 8192
+    prices:
+      input: 0.3
+      cached: 0.03
+      output: 1.2
+
+  MiniMax-M2.7-highspeed:
+    description: High-speed variant of MiniMax M2.7 with faster inference
+    capabilities: [TEXT, FUNCTION_CALLING, REASONING]
+    context_length: 204800
+    max_output_tokens: 8192
+    prices:
+      input: 0.6
+      cached: 0.03
+      output: 2.4
+
   MiniMax-M2.5:
     description: MiniMax flagship model with strong text generation and function calling capabilities
     capabilities: [TEXT, FUNCTION_CALLING]

--- a/aipyapp/res/models.yaml
+++ b/aipyapp/res/models.yaml
@@ -214,8 +214,18 @@ Anthropic:
       output: 15.00
 
 MiniMax:
+  MiniMax-M3:
+    description: MiniMax flagship model with 512K context, 128K max output, image input, and reasoning support
+    capabilities: [TEXT, IMAGE_INPUT, FUNCTION_CALLING, REASONING]
+    context_length: 524288
+    max_output_tokens: 131072
+    prices:
+      input: 0.6
+      cached: 0.12
+      output: 2.4
+
   MiniMax-M2.7:
-    description: MiniMax latest flagship model with enhanced reasoning, text generation and function calling
+    description: Previous-generation MiniMax model with enhanced reasoning, text generation and function calling
     capabilities: [TEXT, FUNCTION_CALLING, REASONING]
     context_length: 204800
     max_output_tokens: 8192
@@ -227,26 +237,6 @@ MiniMax:
   MiniMax-M2.7-highspeed:
     description: High-speed variant of MiniMax M2.7 with faster inference
     capabilities: [TEXT, FUNCTION_CALLING, REASONING]
-    context_length: 204800
-    max_output_tokens: 8192
-    prices:
-      input: 0.6
-      cached: 0.03
-      output: 2.4
-
-  MiniMax-M2.5:
-    description: MiniMax flagship model with strong text generation and function calling capabilities
-    capabilities: [TEXT, FUNCTION_CALLING]
-    context_length: 204800
-    max_output_tokens: 8192
-    prices:
-      input: 0.3
-      cached: 0.03
-      output: 1.2
-
-  MiniMax-M2.5-highspeed:
-    description: High-speed variant of MiniMax M2.5 with faster inference
-    capabilities: [TEXT, FUNCTION_CALLING]
     context_length: 204800
     max_output_tokens: 8192
     prices:

--- a/aipyapp/res/models.yaml
+++ b/aipyapp/res/models.yaml
@@ -213,6 +213,27 @@ Anthropic:
       cached: 0.30
       output: 15.00
 
+MiniMax:
+  MiniMax-M2.5:
+    description: MiniMax flagship model with strong text generation and function calling capabilities
+    capabilities: [TEXT, FUNCTION_CALLING]
+    context_length: 204800
+    max_output_tokens: 8192
+    prices:
+      input: 0.3
+      cached: 0.03
+      output: 1.2
+
+  MiniMax-M2.5-highspeed:
+    description: High-speed variant of MiniMax M2.5 with faster inference
+    capabilities: [TEXT, FUNCTION_CALLING]
+    context_length: 204800
+    max_output_tokens: 8192
+    prices:
+      input: 0.6
+      cached: 0.03
+      output: 2.4
+
 MoonShot:
   kimi-latest:
     description: the latest version of the Kimi large model


### PR DESCRIPTION
## Summary

Add MiniMax as a first-class LLM provider for aipyapp, with the latest **MiniMax-M3** model as the default.

### Changes

- **Provider configuration** (`aipyapp/config/llm.py`): Added MiniMax provider entry with `api.minimax.io/v1` base URL
- **Client implementation** (`aipyapp/llm/manager.py`): Added `MiniMaxClient` extending `OpenAIBaseClient` with **MiniMax-M3** as default model
- **Model catalog** (`aipyapp/res/models.yaml`): Added 3 MiniMax model entries:
  - `MiniMax-M3` — **default**: 512K context, 128K max output, supports image input, reasoning
  - `MiniMax-M2.7` — previous-generation flagship with reasoning support
  - `MiniMax-M2.7-highspeed` — high-speed variant of M2.7

### Configuration

```json
{
  "MiniMax": {
    "api_key": "your-minimax-api-key",
    "type": "minimax"
  }
}
```

Get an API key at https://platform.minimaxi.com

### Why MiniMax-M3?

MiniMax-M3 is the latest MiniMax model, featuring:
- **512K context window** (vs. 200K in M2.7)
- **Up to 128K output tokens**
- **Image input** support (OpenAI-compatible vision API)
- Enhanced reasoning, function calling, and text generation
- Served via OpenAI-compatible API at `api.minimax.io/v1`

MiniMax-M2.7 and MiniMax-M2.7-highspeed remain available for users who prefer the previous generation. Older models (M2.5 series) have been dropped.
