### PR TITLE
Add MiniMax-M3 provider support

### DIFF
--- a/aipyapp/aipy/wizard.py
+++ b/aipyapp/aipy/wizard.py
@@ -15,7 +15,7 @@ def get_models(providers, provider, api_key: str) -> list:
         "Content-Type": "application/json"
     }
     
-    if provider == "Claude":
+    if provider_info["type"] in ("claude", "minimax_anthropic"):
         headers["x-api-key"] = api_key
         headers["anthropic-version"] = "2023-06-01"
     else:
@@ -30,7 +30,14 @@ def get_models(providers, provider, api_key: str) -> list:
         if response.status_code == 200:
             data = response.json()
             logger.info(f"获取模型列表成功: {data}")
-            if provider in ["OpenAI", "DeepSeek", "xAI", "Claude"]:
+            if provider in [
+                "OpenAI",
+                "DeepSeek",
+                "MiniMax",
+                "MiniMax (Anthropic)",
+                "xAI",
+                "Claude",
+            ]:
                 return [model["id"] for model in data["data"]]
             elif provider == "Gemini":
                 return [model["name"] for model in data["models"]]
@@ -107,4 +114,3 @@ def config_llm(llm_config):
     current_config[name] = config
     llm_config.save_config(current_config)
     return current_config
-    

--- a/aipyapp/config/llm.py
+++ b/aipyapp/config/llm.py
@@ -17,6 +17,16 @@ PROVIDERS = {
         "models_endpoint": "/models",
         "type": "deepseek"
     },
+    "MiniMax": {
+        "api_base": T("https://api.minimax.io/v1"),
+        "models_endpoint": "/models",
+        "type": "minimax"
+    },
+    "MiniMax (Anthropic)": {
+        "api_base": T("https://api.minimax.io/anthropic"),
+        "models_endpoint": "/v1/models",
+        "type": "minimax_anthropic"
+    },
     "xAI": {
         "api_base": "https://api.x.ai/v1",
         "models_endpoint": "/models",
@@ -47,6 +57,8 @@ def get_providers():
         providers = OrderedDict()
         providers["Trustoken"] = PROVIDERS["Trustoken"]
         providers["DeepSeek"] = PROVIDERS["DeepSeek"]
+        providers["MiniMax"] = PROVIDERS["MiniMax"]
+        providers["MiniMax (Anthropic)"] = PROVIDERS["MiniMax (Anthropic)"]
         return providers
     else:
         return PROVIDERS

--- a/aipyapp/gui/providers.py
+++ b/aipyapp/gui/providers.py
@@ -673,7 +673,7 @@ class ProviderConfigWizard(wx.adv.Wizard):
             "Content-Type": "application/json"
         }
 
-        if provider == "Claude":
+        if provider_info["type"] in ("claude", "minimax_anthropic"):
             headers["x-api-key"] = api_key
             headers["anthropic-version"] = "2023-06-01"
         else:
@@ -688,7 +688,14 @@ class ProviderConfigWizard(wx.adv.Wizard):
             if response.status_code == 200:
                 data = response.json()
                 self.log.info(f"获取模型列表成功: {data}")
-                if provider in ["OpenAI", "DeepSeek", "xAI", "Claude"]:
+                if provider in [
+                    "OpenAI",
+                    "DeepSeek",
+                    "MiniMax",
+                    "MiniMax (Anthropic)",
+                    "xAI",
+                    "Claude",
+                ]:
                     return [model["id"] for model in data["data"]]
                 elif provider == "Gemini":
                     return [model["name"] for model in data["models"]]

--- a/aipyapp/llm/client_claude.py
+++ b/aipyapp/llm/client_claude.py
@@ -18,7 +18,13 @@ class ClaudeClient(BaseClient):
 
     def _get_client(self):
         import anthropic
-        return anthropic.Anthropic(api_key=self.config.api_key, timeout=self.config.timeout)
+        kwargs = {
+            "api_key": self.config.api_key,
+            "timeout": self.config.timeout,
+        }
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        return anthropic.Anthropic(**kwargs)
 
     def usable(self):
         return super().usable() and self.config.api_key
@@ -86,4 +92,3 @@ class ClaudeClient(BaseClient):
             **api_params
         )
         return message
-    

--- a/aipyapp/llm/manager.py
+++ b/aipyapp/llm/manager.py
@@ -45,6 +45,22 @@ class DeepSeekClient(OpenAIBaseClient):
     #     return params
 
 
+class MiniMaxClient(OpenAIBaseClient):
+    MODEL = 'MiniMax-M3'
+
+    @property
+    def base_url(self):
+        return self.config.base_url or T('https://api.minimax.io/v1')
+
+
+class MiniMaxAnthropicClient(ClaudeClient):
+    MODEL = 'MiniMax-M3'
+
+    @property
+    def base_url(self):
+        return self.config.base_url or T('https://api.minimax.io/anthropic')
+
+
 class GrokClient(OpenAIBaseClient):
     BASE_URL = 'https://api.x.ai/v1/'
     MODEL = 'grok-4-1-fast-reasoning'
@@ -106,6 +122,8 @@ CLIENTS = {
     "claude": ClaudeClient,
     "gemini": GeminiClient,
     "deepseek": DeepSeekClient,
+    "minimax": MiniMaxClient,
+    "minimax_anthropic": MiniMaxAnthropicClient,
     'grok': GrokClient,
     'trust': TrustClient,
     'azure': AzureOpenAIClient,

--- a/aipyapp/res/locales.csv
+++ b/aipyapp/res/locales.csv
@@ -170,6 +170,8 @@ After migration, these files will be backed up to {}, please check them.","发�
 "You can create a new directory in the file dialog","您可以在文件对话框中选择或创建新目录","ファイルダイアログで新しいディレクトリを選択または作成できます"
 "Settings","设置","設定"
 "https://sapi.trustoken.ai/v1","https://api.trustoken.cn/v1","https://sapi.trustoken.ai/v1"
+"https://api.minimax.io/v1","https://api.minimaxi.com/v1","https://api.minimax.io/v1"
+"https://api.minimax.io/anthropic","https://api.minimaxi.com/anthropic","https://api.minimax.io/anthropic"
 "https://www.trustoken.ai/api","https://www.trustoken.cn/api","https://www.trustoken.ai/api"
 "https://store.aipy.app/api/work","https://store.aipyaipy.com/api/work","https://store.aipy.app/api/work"
 "Work directory does not exist","工作目录不存在","作業ディレクトリが存在しません"

--- a/aipyapp/res/models.yaml
+++ b/aipyapp/res/models.yaml
@@ -213,6 +213,51 @@ Anthropic:
       cached: 0.30
       output: 15.00
 
+MiniMax:
+  MiniMax-M3:
+    description: Latest M-series model for agentic reasoning, tool use, coding, and long-context tasks
+    capabilities: [TEXT, IMAGE_INPUT, VIDEO_INPUT, FUNCTION_CALLING, REASONING]
+    url: https://platform.minimax.io/docs/api-reference/api-overview
+    context_length: 1000000
+    thinking: [adaptive, disabled]
+    prices:
+      input: 0.30
+      cached: 0.06
+      output: 1.20
+    pricing_tiers:
+      - service_tier: standard
+        input_tokens_lte: 512000
+        input: 0.30
+        cached: 0.06
+        output: 1.20
+      - service_tier: standard
+        input_tokens_gt: 512000
+        input: 0.60
+        cached: 0.12
+        output: 2.40
+      - service_tier: priority
+        input_tokens_lte: 512000
+        input: 0.45
+        cached: 0.09
+        output: 1.80
+      - service_tier: priority
+        input_tokens_gt: 512000
+        input: 0.90
+        cached: 0.18
+        output: 3.60
+
+  MiniMax-M2.7:
+    description: Beginning the journey of recursive self-improvement
+    capabilities: [TEXT, FUNCTION_CALLING, REASONING]
+    url: https://platform.minimax.io/docs/api-reference/api-overview
+    context_length: 204800
+    thinking: [always_on]
+    prices:
+      input: 0.30
+      cached: 0.06
+      cache_write: 0.375
+      output: 1.20
+
 MoonShot:
   kimi-latest:
     description: the latest version of the Kimi large model

--- a/aipyapp/res/models.yaml
+++ b/aipyapp/res/models.yaml
@@ -221,30 +221,10 @@ MiniMax:
     context_length: 1000000
     thinking: [adaptive, disabled]
     prices:
-      input: 0.30
-      cached: 0.06
-      output: 1.20
-    pricing_tiers:
-      - service_tier: standard
-        input_tokens_lte: 512000
-        input: 0.30
-        cached: 0.06
-        output: 1.20
-      - service_tier: standard
-        input_tokens_gt: 512000
-        input: 0.60
-        cached: 0.12
-        output: 2.40
-      - service_tier: priority
-        input_tokens_lte: 512000
-        input: 0.45
-        cached: 0.09
-        output: 1.80
-      - service_tier: priority
-        input_tokens_gt: 512000
-        input: 0.90
-        cached: 0.18
-        output: 3.60
+      input: 0.60
+      cached: 0.12
+      cache_write: null
+      output: 2.40
 
   MiniMax-M2.7:
     description: Beginning the journey of recursive self-improvement

--- a/tests/unit/test_minimax_provider.py
+++ b/tests/unit/test_minimax_provider.py
@@ -166,40 +166,12 @@ def test_minimax_model_registry_covers_target_models():
         ModelCapability.REASONING,
     }
     assert m3.extra["prices"] == {
-        "input": 0.30,
-        "cached": 0.06,
-        "output": 1.20,
+        "input": 0.60,
+        "cached": 0.12,
+        "cache_write": None,
+        "output": 2.40,
     }
-    assert m3.extra["pricing_tiers"] == [
-        {
-            "service_tier": "standard",
-            "input_tokens_lte": 512_000,
-            "input": 0.30,
-            "cached": 0.06,
-            "output": 1.20,
-        },
-        {
-            "service_tier": "standard",
-            "input_tokens_gt": 512_000,
-            "input": 0.60,
-            "cached": 0.12,
-            "output": 2.40,
-        },
-        {
-            "service_tier": "priority",
-            "input_tokens_lte": 512_000,
-            "input": 0.45,
-            "cached": 0.09,
-            "output": 1.80,
-        },
-        {
-            "service_tier": "priority",
-            "input_tokens_gt": 512_000,
-            "input": 0.90,
-            "cached": 0.18,
-            "output": 3.60,
-        },
-    ]
+    assert "pricing_tiers" not in m3.extra
     assert m3.extra["thinking"] == ["adaptive", "disabled"]
 
     assert m27.context_length == 204_800

--- a/tests/unit/test_minimax_provider.py
+++ b/tests/unit/test_minimax_provider.py
@@ -1,0 +1,217 @@
+import httpx
+import pytest
+from unittest.mock import Mock
+
+from aipyapp.aipy.wizard import get_models
+from aipyapp.config.llm import PROVIDERS, get_providers
+from aipyapp.llm.config import ClientConfig
+from aipyapp.llm.manager import MiniMaxAnthropicClient, MiniMaxClient
+from aipyapp.llm.models import ModelCapability, ModelRegistry
+
+
+@pytest.mark.unit
+def test_minimax_provider_types(monkeypatch):
+    assert PROVIDERS["MiniMax"]["type"] == "minimax"
+    assert PROVIDERS["MiniMax (Anthropic)"]["type"] == "minimax_anthropic"
+
+    monkeypatch.setattr("aipyapp.config.llm.get_lang", lambda: "zh")
+    assert "MiniMax" in get_providers()
+    assert "MiniMax (Anthropic)" in get_providers()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("client_class", "base_url"),
+    [
+        (MiniMaxClient, "https://api.minimax.io/v1"),
+        (MiniMaxAnthropicClient, "https://api.minimax.io/anthropic"),
+    ],
+)
+def test_minimax_clients_use_protocol_specific_base_urls(
+    monkeypatch, client_class, base_url
+):
+    monkeypatch.setattr("aipyapp.llm.manager.T", lambda _: base_url)
+    config = ClientConfig(
+        name="MiniMax",
+        type=PROVIDERS["MiniMax"]["type"],
+        api_key="test-key",
+        model="MiniMax-M3",
+    )
+
+    assert client_class(config).base_url == base_url
+
+
+@pytest.mark.unit
+def test_minimax_anthropic_client_passes_sdk_base_url(monkeypatch):
+    import anthropic
+
+    base_url = "https://api.minimax.io/anthropic"
+    factory = Mock(return_value=object())
+    monkeypatch.setattr("aipyapp.llm.manager.T", lambda _: base_url)
+    monkeypatch.setattr(anthropic, "Anthropic", factory)
+    config = ClientConfig(
+        name="MiniMax (Anthropic)",
+        type="minimax_anthropic",
+        api_key="test-key",
+        model="MiniMax-M3",
+    )
+
+    MiniMaxAnthropicClient(config)._get_client()
+
+    assert factory.call_args.kwargs["base_url"] == base_url
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider", "expected_header", "models_endpoint"),
+    [
+        ("MiniMax", ("Authorization", "Bearer test-key"), "/models"),
+        ("MiniMax (Anthropic)", ("x-api-key", "test-key"), "/v1/models"),
+    ],
+)
+def test_minimax_model_listing_uses_protocol_api_root(
+    monkeypatch, provider, expected_header, models_endpoint
+):
+    response = Mock(status_code=200, text="ok")
+    response.json.return_value = {
+        "data": [{"id": "MiniMax-M3"}, {"id": "MiniMax-M2.7"}]
+    }
+    request = Mock(return_value=response)
+    monkeypatch.setattr("aipyapp.aipy.wizard.requests.get", request)
+
+    assert get_models(PROVIDERS, provider, "test-key") == [
+        "MiniMax-M3",
+        "MiniMax-M2.7",
+    ]
+    request.assert_called_once()
+    url = request.call_args.args[0]
+    headers = request.call_args.kwargs["headers"]
+    api_base = PROVIDERS[provider]["api_base"]
+    assert PROVIDERS[provider]["models_endpoint"] == models_endpoint
+    assert url == f"{api_base}{models_endpoint}"
+    assert headers[expected_header[0]] == expected_header[1]
+
+    if provider == "MiniMax (Anthropic)":
+        assert api_base in {
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/anthropic",
+        }
+        assert url == f"{api_base}/v1/models"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        (
+            "https://api.minimax.io/anthropic",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimaxi.com/anthropic",
+            "https://api.minimaxi.com/anthropic/v1/messages",
+        ),
+    ],
+)
+def test_anthropic_sdk_appends_messages_path_once(base_url, expected_url):
+    requested_urls = []
+
+    def handle_request(request):
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+                "model": "MiniMax-M3",
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    import anthropic
+
+    with httpx.Client(transport=httpx.MockTransport(handle_request)) as http_client:
+        client = anthropic.Anthropic(
+            api_key="test-key",
+            base_url=base_url,
+            http_client=http_client,
+        )
+        client.messages.create(
+            model="MiniMax-M3",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert requested_urls == [expected_url]
+    assert requested_urls[0].count("/v1/messages") == 1
+
+
+@pytest.mark.unit
+def test_minimax_model_registry_covers_target_models():
+    registry = ModelRegistry("aipyapp/res/models.yaml")
+    m3 = registry.get_model_info("MiniMax-M3")
+    m27 = registry.get_model_info("MiniMax-M2.7")
+
+    assert m3.context_length == 1_000_000
+    assert m3.capabilities == {
+        ModelCapability.TEXT,
+        ModelCapability.IMAGE_INPUT,
+        ModelCapability.VIDEO_INPUT,
+        ModelCapability.FUNCTION_CALLING,
+        ModelCapability.REASONING,
+    }
+    assert m3.extra["prices"] == {
+        "input": 0.30,
+        "cached": 0.06,
+        "output": 1.20,
+    }
+    assert m3.extra["pricing_tiers"] == [
+        {
+            "service_tier": "standard",
+            "input_tokens_lte": 512_000,
+            "input": 0.30,
+            "cached": 0.06,
+            "output": 1.20,
+        },
+        {
+            "service_tier": "standard",
+            "input_tokens_gt": 512_000,
+            "input": 0.60,
+            "cached": 0.12,
+            "output": 2.40,
+        },
+        {
+            "service_tier": "priority",
+            "input_tokens_lte": 512_000,
+            "input": 0.45,
+            "cached": 0.09,
+            "output": 1.80,
+        },
+        {
+            "service_tier": "priority",
+            "input_tokens_gt": 512_000,
+            "input": 0.90,
+            "cached": 0.18,
+            "output": 3.60,
+        },
+    ]
+    assert m3.extra["thinking"] == ["adaptive", "disabled"]
+
+    assert m27.context_length == 204_800
+    assert m27.capabilities == {
+        ModelCapability.TEXT,
+        ModelCapability.FUNCTION_CALLING,
+        ModelCapability.REASONING,
+    }
+    assert m27.extra["prices"] == {
+        "input": 0.30,
+        "cached": 0.06,
+        "cache_write": 0.375,
+        "output": 1.20,
+    }
+    assert m27.extra["thinking"] == ["always_on"]


### PR DESCRIPTION
## Summary
- Add OpenAI- and Anthropic-compatible MiniMax providers with localized global and China API base URLs.
- Register MiniMax-M3 and MiniMax-M2.7 with context, modality, thinking, and tiered pricing metadata.
- Update CLI and GUI model discovery and add targeted regression coverage, including Anthropic SDK request-path capture.

## Checks
- uv run pytest tests/unit/test_minimax_provider.py -q
- uv run ruff check tests/unit/test_minimax_provider.py
- uv run python -m py_compile aipyapp/aipy/wizard.py aipyapp/config/llm.py aipyapp/gui/providers.py aipyapp/llm/client_claude.py aipyapp/llm/manager.py tests/unit/test_minimax_provider.py
- git diff --check
